### PR TITLE
Refactor to central GeminiClient

### DIFF
--- a/src/spatial_guidance/spatial_guidance/gemini_client/__init__.py
+++ b/src/spatial_guidance/spatial_guidance/gemini_client/__init__.py
@@ -9,6 +9,7 @@ from .gemini_client import (
     ModePromptTemplates,
     OperationalMode,
 )
+from .gemini_live import GeminiLive
 
 __all__ = [
     "GeminiClient",
@@ -16,4 +17,5 @@ __all__ = [
     "OperationalMode",
     "ChatMessage",
     "ModePromptTemplates",
+    "GeminiLive",
 ]

--- a/src/spatial_guidance/spatial_guidance/gemini_client/gemini_client.py
+++ b/src/spatial_guidance/spatial_guidance/gemini_client/gemini_client.py
@@ -1,11 +1,7 @@
-"""
-Dedicated Gemini Client module for the Spatial Understanding Agent.
-Handles client initialization, chat history management, and operational modes.
-"""
+"""Simplified Gemini client for all scene understanding models."""
 
 from enum import Enum
-from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Type
 
 from google import genai
 from google.genai import types
@@ -34,6 +30,8 @@ class ChatMessage(BaseModel):
     mode: OperationalMode
     frame_idx: Optional[int] = None
     metadata: Dict[str, Any] = Field(default_factory=dict)
+    tags: List[str] = Field(default_factory=list)
+    """Optional tags describing the message content."""
 
 
 class ModePromptTemplates:
@@ -126,23 +124,13 @@ class ModePromptTemplates:
 
 
 class GeminiClientConfig(BaseConfig["GeminiClient"]):
-    """Configuration for the Gemini Client."""
+    """Configuration for :class:`GeminiClient`."""
 
+    target: Type["GeminiClient"] = Field(default_factory=lambda: GeminiClient)
     model_name: str = "gemini-2.5-pro-preview-05-06"
-    """Gemini model to use for conversations."""
-
     max_history_length: int = 20
-    """Maximum number of messages to keep in chat history."""
-
     context_window_size: int = 10
-    """Number of recent messages to include in context for each request."""
-
-    auto_mode_detection: bool = True
-    """Whether to automatically detect operational mode from user input."""
-
     temperature: float = 0.7
-    """Controls randomness in responses."""
-
     safety_settings: List[Tuple[str, str]] = Field(
         default_factory=lambda: [
             ("HARM_CATEGORY_DANGEROUS_CONTENT", "BLOCK_ONLY_HIGH"),
@@ -154,20 +142,12 @@ class GeminiClientConfig(BaseConfig["GeminiClient"]):
 
 
 class GeminiClient:
-    """
-    Dedicated Gemini client for the Spatial Understanding Agent.
-    Handles client initialization, chat history management, and operational modes.
-    """
+    """Central Gemini interface used by all scene understanding models."""
 
-    def __init__(self, config: Optional[GeminiClientConfig] = None):
-        """Initialize the Gemini client with configuration."""
+    def __init__(self, config: Optional[GeminiClientConfig] = None) -> None:
         self.config = config or GeminiClientConfig()
         self.console = Console.with_prefix(self.__class__.__name__)
-
-        # Initialize Gemini client
         self.client = genai.Client(api_key=PathConfig().get_api_key("GOOGLE_API_KEY"))
-
-        # Chat history and state management
         self.chat_history: List[ChatMessage] = []
         self.current_mode = OperationalMode.GENERAL_SCENE
         self.mode_templates = ModePromptTemplates()
@@ -176,120 +156,71 @@ class GeminiClient:
             f"Initialized Gemini client with model: {self.config.model_name}"
         )
 
-    def detect_operational_mode(self, user_input: str) -> OperationalMode:
-        """
-        Automatically detect the appropriate operational mode based on user input.
-        """
-        if not self.config.auto_mode_detection:
-            return self.current_mode
-
+    # ------------------------------------------------------------------
+    # Conversation utilities
+    # ------------------------------------------------------------------
+    def _detect_mode(self, user_input: str) -> OperationalMode:
+        """Simple keyword based mode detection."""
         user_lower = user_input.lower()
-
-        # Check each mode's context filters
-        mode_scores = {}
         for mode, template in self.mode_templates.TEMPLATES.items():
-            score = sum(
-                1 for keyword in template["context_filter"] if keyword in user_lower
-            )
-            if score > 0:
-                mode_scores[mode] = score
-
-        if mode_scores:
-            # Return mode with highest score
-            detected_mode = max(mode_scores.keys(), key=lambda k: mode_scores[k])
-            if detected_mode != self.current_mode:
-                self.console.log(
-                    f"Mode switch detected: {self.current_mode.value} → {detected_mode.value}"
-                )
-                self.current_mode = detected_mode
-            return detected_mode
-
+            if any(k in user_lower for k in template["context_filter"]):
+                if mode != self.current_mode:
+                    self.console.log(
+                        f"Mode switch detected: {self.current_mode.value} → {mode.value}"
+                    )
+                self.current_mode = mode
+                return mode
         return self.current_mode
 
-    def filter_chat_history(
-        self, mode: OperationalMode, current_input: str = ""
-    ) -> List[ChatMessage]:
-        """
-        Filter chat history based on operational mode and relevance to current input.
-        """
-        if not self.chat_history:
-            return []
-
-        # Get relevant keywords for the current mode
-        mode_keywords = self.mode_templates.TEMPLATES[mode]["context_filter"]
-        input_lower = current_input.lower()
-
-        # Filter messages by relevance
-        relevant_messages = []
-        for message in self.chat_history[-self.config.context_window_size :]:
-            message_lower = message.content.lower()
-
-            # Include if same mode or contains relevant keywords
-            if (
-                message.mode == mode
-                or any(keyword in message_lower for keyword in mode_keywords)
-                or any(
-                    keyword in input_lower and keyword in message_lower
-                    for keyword in mode_keywords
-                )
-            ):
-                relevant_messages.append(message)
-
-        return relevant_messages[-self.config.context_window_size :]
-
     def add_message(
-        self,
-        role: str,
-        content: str,
-        frame_idx: Optional[int] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        self, role: str, content: str, *, tags: Optional[List[str]] = None
     ) -> None:
-        """Add a message to chat history with current mode context."""
         import time
 
-        message = ChatMessage(
-            role=role,
-            content=content,
-            timestamp=time.time(),
-            mode=self.current_mode,
-            frame_idx=frame_idx,
-            metadata=metadata or {},
+        self.chat_history.append(
+            ChatMessage(
+                role=role,
+                content=content,
+                timestamp=time.time(),
+                mode=self.current_mode,
+                frame_idx=None,
+                metadata={},
+                tags=tags or [],
+            )
         )
 
-        self.chat_history.append(message)
-
-        # Trim history if too long
         if len(self.chat_history) > self.config.max_history_length:
             self.chat_history = self.chat_history[-self.config.max_history_length :]
 
-    def generate_response(
-        self, user_input: str, frame: DatasetOut, frame_idx: int
-    ) -> Tuple[str, OperationalMode]:
-        """
-        Generate a response using the current operational mode and filtered history.
-        """
-        # Detect and set operational mode
-        mode = self.detect_operational_mode(user_input)
+    def get_context(self, tags: Optional[List[str]] = None) -> List[ChatMessage]:
+        tags = set(tags or [])
+        history = self.chat_history[-self.config.context_window_size :]
+        if not tags:
+            return history
+        return [m for m in history if tags.intersection(m.tags)]
 
-        # Get mode-specific system prompt
+    # ------------------------------------------------------------------
+    # Gemini interaction
+    # ------------------------------------------------------------------
+    def generate_response(
+        self,
+        user_input: str,
+        frame: DatasetOut,
+        *,
+        parts: Optional[List[types.Part]] = None,
+        tags: Optional[List[str]] = None,
+    ) -> Tuple[str, OperationalMode]:
+        mode = self._detect_mode(user_input)
         system_prompt = self.mode_templates.TEMPLATES[mode]["system"]
 
-        # Filter relevant chat history
-        relevant_history = self.filter_chat_history(mode, user_input)
-
-        # Build contents for Gemini
-        contents: List[types.Content] = [frame.rgb_image]
-
-        # Add system prompt
+        context = self.get_context(tags)
+        contents: List[types.Content] = []
+        contents.extend(parts or [frame.rgb_image])
         contents.append(types.Part.from_text(text=f"System: {system_prompt}"))
-
-        # Add relevant chat history
-        for msg in relevant_history:
+        for msg in context:
             contents.append(
                 types.Part.from_text(text=f"{msg.role.title()}: {msg.content}")
             )
-
-        # Add current user input
         contents.append(types.Part.from_text(text=f"User: {user_input}"))
 
         try:
@@ -299,60 +230,44 @@ class GeminiClient:
                 generation_config=types.GenerateContentConfig(
                     temperature=self.config.temperature,
                     safety_settings=[
-                        types.SafetySetting(category=cat, threshold=thresh)
-                        for cat, thresh in self.config.safety_settings
+                        types.SafetySetting(category=c, threshold=t)
+                        for c, t in self.config.safety_settings
                     ],
                 ),
             )
+            text = response.text or ""
+        except Exception as e:  # pragma: no cover - network errors
+            self.console.warn(f"Gemini error: {e}")
+            text = ""
 
-            response_text = (
-                response.text or "I'm sorry, I couldn't process that request."
+        self.add_message("user", user_input, tags=tags)
+        self.add_message("assistant", text, tags=tags)
+        return text, mode
+
+    def generate_content(
+        self,
+        *,
+        parts: List[types.Part],
+        generation_config: types.GenerateContentConfig,
+        tags: Optional[List[str]] = None,
+    ) -> types.GenerateContentResponse:
+        """Low level wrapper to call the Gemini API and record the response."""
+        try:
+            response = self.client.models.generate_content(
+                model=self.config.model_name,
+                contents=parts,
+                generation_config=generation_config,
             )
+            text = response.text or ""
+        except Exception as e:  # pragma: no cover - network errors
+            self.console.warn(f"Gemini error: {e}")
+            raise
 
-            # Add messages to history
-            self.add_message("user", user_input, frame_idx)
-            self.add_message("assistant", response_text, frame_idx)
-
-            return response_text, mode
-
-        except Exception as e:
-            self.console.log(f"Error generating response: {e}")
-            error_msg = "I'm sorry, I encountered an error processing your request."
-            self.add_message("user", user_input, frame_idx)
-            self.add_message("assistant", error_msg, frame_idx)
-            return error_msg, mode
+        self.add_message("assistant", text, tags=tags)
+        return response
 
     def clear_history(self) -> None:
-        """Clear all chat history."""
         self.chat_history.clear()
-        self.console.log("Chat history cleared")
 
-    def set_mode(self, mode: OperationalMode) -> None:
-        """Manually set the operational mode."""
-        old_mode = self.current_mode
-        self.current_mode = mode
-        self.console.log(f"Mode manually set: {old_mode.value} → {mode.value}")
 
-    def get_mode_description(self, mode: OperationalMode) -> str:
-        """Get a human-readable description of an operational mode."""
-        descriptions = {
-            OperationalMode.GENERAL_SCENE: "General scene understanding and description",
-            OperationalMode.OBJECT_DETECTION: "Specific object detection and location",
-            OperationalMode.COOKING_ASSISTANCE: "Kitchen and cooking assistance",
-            OperationalMode.NAVIGATION_GUIDANCE: "Navigation and mobility guidance",
-            OperationalMode.ACCESSIBILITY_SUPPORT: "Accessibility and interaction support",
-        }
-        return descriptions.get(mode, mode.value)
 
-    def get_conversation_summary(self) -> Dict[str, Any]:
-        """Get a summary of the current conversation state."""
-        mode_counts: Dict[str, int] = {}
-        for msg in self.chat_history:
-            mode_counts[msg.mode.value] = mode_counts.get(msg.mode.value, 0) + 1
-
-        return {
-            "current_mode": self.current_mode.value,
-            "total_messages": len(self.chat_history),
-            "mode_distribution": mode_counts,
-            "recent_messages": len([m for m in self.chat_history[-5:]]),
-        }

--- a/src/spatial_guidance/spatial_guidance/gemini_client/gemini_live.py
+++ b/src/spatial_guidance/spatial_guidance/gemini_client/gemini_live.py
@@ -1,0 +1,126 @@
+"""Gemini Live API model wrapper."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Iterable, List, Optional
+
+from google import genai
+from google.genai import types
+
+from ..utils import Console
+from ..data_contracts.dataset import DatasetOut
+from .gemini_client import GeminiClient, GeminiClientConfig
+
+
+class GeminiLive:
+    """Wrapper around the Gemini Live API using :class:`GeminiClient`."""
+
+    def __init__(
+        self,
+        config: Optional[GeminiClientConfig] = None,
+        *,
+        gemini_client: Optional[GeminiClient] = None,
+    ) -> None:
+        self.config = config or GeminiClientConfig(
+            model_name="gemini-2.0-flash-live-001"
+        )
+        self.console = Console.with_prefix(self.__class__.__name__)
+        self.gemini_client = gemini_client or GeminiClient(self.config)
+        self.model = genai.GenerativeModel(self.config.model_name)
+
+        self.console.log(
+            f"Initialized GeminiLive with model: {self.config.model_name}"
+        )
+
+    # ------------------------------------------------------------------
+    # Function calling
+    # ------------------------------------------------------------------
+    def _build_tools(self) -> List[types.Tool]:
+        """Return default tools for expert model function calls."""
+
+        detect_schema = types.Schema(
+            type=types.Type.OBJECT,
+            properties={
+                "image": types.Schema(type=types.Type.BYTES, format="jpeg"),
+                "prompt": types.Schema(type=types.Type.STRING),
+            },
+            required=["image"],
+        )
+
+        aabb_func = types.FunctionDeclaration(
+            name="run_aabb_detection",
+            description="Detect AABBs in an image",
+            parameters=detect_schema,
+        )
+        obb_func = types.FunctionDeclaration(
+            name="run_obb_detection",
+            description="Detect OBBs in an image",
+            parameters=detect_schema,
+        )
+
+        return [types.Tool(function_declarations=[aabb_func, obb_func])]
+
+    def _dispatch_function(self, name: str, args: Dict[str, Any]) -> str:
+        """Call expert models based on Gemini function calls."""
+        image = args.get("image")
+        prompt = args.get("prompt")
+        import numpy as np
+
+        dataset = DatasetOut(
+            rgb_image=image,
+            depth_image=image.convert("L"),
+            camera_intrinsics=args.get("camera_intrinsics") or np.eye(3),
+            camera_pose=args.get("camera_pose") or np.eye(4),
+        )
+
+        if name == "run_aabb_detection":
+            from ..scene_understanding import gemini_aabb_detection
+
+            detector = gemini_aabb_detection.GeminiAABBDetSeg(gemini_aabb_detection.GeminiAABBDetSegConfig(), gemini_client=self.gemini_client)
+            dets = detector.run_aabb_detection(dataset, prompt, subset_mode=bool(prompt))
+            return dets.to_json_list()
+        if name == "run_obb_detection":
+            from ..scene_understanding import gemini_obb_detection
+
+            detector = gemini_obb_detection.GeminiOBBDet(gemini_obb_detection.GeminiOBBDetConfig(),)
+            dets = detector.entrypoint(dataset)
+            return dets.to_json_list()
+
+        self.console.warn(f"Unknown function call: {name}")
+        return ""
+
+    # ------------------------------------------------------------------
+    # Interaction
+    # ------------------------------------------------------------------
+    def stream(
+        self,
+        parts: Iterable[types.Part],
+        *,
+        tags: Optional[List[str]] = None,
+    ) -> Iterable[types.GenerateContentResponse]:
+        """Stream responses from the live API and handle function calls."""
+        tools = self._build_tools()
+        chat = self.model.start_chat(tools=tools)
+        for response in chat.send_iter(parts):
+            if response.candidates and response.candidates[0].content.parts:
+                part = response.candidates[0].content.parts[0]
+                if isinstance(part, types.FunctionCall):
+                    result = self._dispatch_function(part.name, part.args)
+                    yield from chat.send_iter([
+                        types.Part.from_function_response(
+                            name=part.name, response=result
+                        )
+                    ])
+                    continue
+            self.gemini_client.add_message(
+                "assistant", response.text or "", tags=tags
+            )
+            yield response
+
+    def chat(self, text: str, frame: DatasetOut) -> str:
+        """Simple helper for text+image chat with the live model."""
+        self.gemini_client.add_message("user", text, tags=["live"])
+        parts = [frame.rgb_image, types.Part.from_text(text)]
+        responses = list(self.stream(parts, tags=["live"]))
+        return responses[-1].text if responses else ""
+

--- a/src/spatial_guidance/spatial_guidance/response_generation/response_generator.py
+++ b/src/spatial_guidance/spatial_guidance/response_generation/response_generator.py
@@ -4,18 +4,14 @@ Uses pure Gemini models to generate contextual responses from structured detecti
 NO hardcoded rules or manual NLP processing - everything is inferred by Gemini.
 """
 
-import asyncio
-import json
-import os
 from enum import Enum
-from typing import Any, AsyncGenerator, Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
-from google import genai
 from google.genai import types
 
 from ..data_contracts.aabb_segmentation import AABBDetection, AABBDetections
-from ..gemini_client import OperationalMode
-from ..utils import Console, PathConfig
+from ..gemini_client import GeminiClient, GeminiClientConfig, OperationalMode
+from ..utils import Console
 
 
 class DirectionalStyle(Enum):
@@ -41,25 +37,19 @@ class ResponseGenerator:
     Simplified implementation that uses the structured JSON output from detections.
     """
 
-    def __init__(self, api_key: Optional[str] = None):
+    def __init__(
+        self,
+        gemini_client: Optional[GeminiClient] = None,
+        model_name: str = "gemini-1.5-flash",
+    ) -> None:
         """Initialize the response generator with Gemini client."""
         self.console = Console.with_prefix(self.__class__.__name__)
-
-        # Initialize Gemini client
-        if api_key is None:
-            # Use PathConfig to load API key from .env file
-            path_config = PathConfig()
-            api_key = path_config.get_api_key("GOOGLE_API_KEY")
-        if not api_key:
-            raise ValueError(
-                "GOOGLE_API_KEY not found in .env file or environment variables"
-            )
-
-        # Create Gemini client
-        self.client = genai.Client(api_key=api_key)
+        self.gemini_client = gemini_client or GeminiClient(
+            GeminiClientConfig(model_name=model_name)
+        )
 
         # Model configuration for response generation
-        self.model_name = "gemini-1.5-flash"
+        self.model_name = model_name
         self.generation_config = types.GenerateContentConfig(
             temperature=0.7,
             top_p=0.9,
@@ -94,12 +84,14 @@ class ResponseGenerator:
             prompt = self._create_prompt(detections_json, mode, user_query)
 
             # Generate response using Gemini
-            response = self.client.models.generate_content(
+            self.gemini_client.add_message("user", prompt, tags=["response"])
+            response = self.gemini_client.client.models.generate_content(
                 model=self.model_name,
                 contents=[types.Part.from_text(text=prompt)],
-                config=self.generation_config,
+                generation_config=self.generation_config,
             )
             result = str(response.text).strip() if response.text else ""
+            self.gemini_client.add_message("assistant", result, tags=["response"])
 
             self.console.log(
                 f"Generated response for {mode.value} mode: {len(result)} characters"

--- a/src/spatial_guidance/spatial_guidance/scene_understanding/gemini_aabb_detection.py
+++ b/src/spatial_guidance/spatial_guidance/scene_understanding/gemini_aabb_detection.py
@@ -1,10 +1,8 @@
 from typing import Annotated, Any, List, Literal, Optional, Tuple, Type, Union
 
 import numpy as np
-from google import genai
 from google.genai import types
 from PIL import Image as PILImage
-from PIL.Image import Image
 from pydantic import Field
 
 from ..data_contracts.aabb_segmentation import (
@@ -13,7 +11,8 @@ from ..data_contracts.aabb_segmentation import (
     RawAABBDetSeg,
 )
 from ..data_contracts.dataset import DatasetOut
-from ..utils import BaseConfig, Console, PathConfig
+from ..utils import BaseConfig, Console
+from ..gemini_client import GeminiClient, GeminiClientConfig
 from ..visualization.detection_visualizer import DetectionVisualizer
 
 
@@ -121,7 +120,11 @@ class GeminiAABBDetSeg:
     """
 
     def __init__(
-        self, config: Optional[GeminiAABBDetSegConfig] = None, **step_kwargs: Any
+        self,
+        config: Optional[GeminiAABBDetSegConfig] = None,
+        *,
+        gemini_client: Optional[GeminiClient] = None,
+        **step_kwargs: Any,
     ):
         """Initialize the Gemini VLM detection model.
 
@@ -132,6 +135,9 @@ class GeminiAABBDetSeg:
         super().__init__(**step_kwargs)
         self.config = config or GeminiAABBDetSegConfig()
         self.visualizer = DetectionVisualizer()
+        self.gemini_client = gemini_client or GeminiClient(
+            GeminiClientConfig(model_name=self.config.model_name)
+        )
 
         CONSOLE.log(f"Initialized Gemini detector with model: {self.config.model_name}")
 
@@ -217,21 +223,22 @@ class GeminiAABBDetSeg:
                 f"Running Gemini detection with model: {self.config.model_name}"
             )
 
-            contents = [
-                rgb_image,
-            ]
+            contents = [rgb_image]
             if user_prompt:
                 contents.append(types.Part.from_text(text=user_prompt))
             else:
                 contents.append(types.Part.from_text(text=self.config.default_prompt))
 
-            # TODO: client should be provided by our GeminiClient class!
-            client = genai.Client(api_key=PathConfig().get_api_key("GOOGLE_API_KEY"))
+            self.gemini_client.add_message(
+                "user",
+                user_prompt or self.config.default_prompt,
+                tags=["aabb"],
+            )
 
-            response = client.models.generate_content(
+            response = self.gemini_client.client.models.generate_content(
                 model=self.config.model_name,
                 contents=contents,
-                config=self.config.get_generation_config(),
+                generation_config=self.config.get_generation_config(),
             )
             parsed_detections: list[RawAABBDetSeg]
             if response.parsed is not None:
@@ -265,6 +272,12 @@ class GeminiAABBDetSeg:
 
             CONSOLE.log(
                 f"{self.config.model_name} detected and parsed {len(parsed_detections)} objects in the scene."
+            )
+
+            self.gemini_client.add_message(
+                "assistant",
+                response.text or "",
+                tags=["aabb"],
             )
 
             return parsed_detections

--- a/src/spatial_guidance/spatial_guidance/scene_understanding/gemini_obb_detection.py
+++ b/src/spatial_guidance/spatial_guidance/scene_understanding/gemini_obb_detection.py
@@ -1,7 +1,6 @@
 from typing import Annotated, Any, List, Literal, Optional, Tuple, Type
 
 import numpy as np
-from google import genai
 from google.genai import types
 from PIL import Image as PILImage
 from pydantic import Field
@@ -11,8 +10,8 @@ from ..data_contracts.aabb_segmentation import AABBDetections
 from ..data_contracts.dataset import DatasetOut
 from ..data_contracts.obb_detection import OBBDetection, OBBDetections, RawOBBDetection
 from ..utils.base_config import BaseConfig
-from ..utils.configs import PathConfig
 from ..utils.console import Console
+from ..gemini_client import GeminiClient, GeminiClientConfig
 from ..visualization.detection_visualizer import DetectionVisualizer
 
 
@@ -92,11 +91,20 @@ class GeminiOBBDetConfig(BaseConfig["GeminiOBBDet"]):
 class GeminiOBBDet(BaseStep):
     """3D OBB Detection model using Google's Gemini multimodal model."""
 
-    def __init__(self, config: Optional[GeminiOBBDetConfig] = None, **step_kwargs: Any):
+    def __init__(
+        self,
+        config: Optional[GeminiOBBDetConfig] = None,
+        *,
+        gemini_client: Optional[GeminiClient] = None,
+        **step_kwargs: Any,
+    ) -> None:
         CONSOLE = Console.with_prefix(self.__class__.__name__)
         super().__init__(**step_kwargs)
         self.config = config or GeminiOBBDetConfig()
         self.visualizer = DetectionVisualizer()
+        self.gemini_client = gemini_client or GeminiClient(
+            GeminiClientConfig(model_name=self.config.model_name)
+        )
 
         CONSOLE.log(
             f"Initialized Gemini 3D OBB detector with model: {self.config.model_name}"
@@ -157,12 +165,10 @@ class GeminiOBBDet(BaseStep):
             if user_prompt:
                 contents.append(types.Part.from_text(text=user_prompt))
 
-            client = genai.Client(api_key=PathConfig().get_api_key("GOOGLE_API_KEY"))
-
-            response = client.models.generate_content(
-                model=self.config.model_name,
-                contents=contents,
-                config=self.config.get_generation_config(),
+            response = self.gemini_client.generate_content(
+                parts=contents,
+                generation_config=self.config.get_generation_config(),
+                tags=["obb"],
             )
 
             if response.parsed is not None:

--- a/src/spatial_guidance/spatial_guidance/scene_understanding/scene_pipeline.py
+++ b/src/spatial_guidance/spatial_guidance/scene_understanding/scene_pipeline.py
@@ -1,8 +1,6 @@
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Union
 
-from google import genai
-from google.genai import types
 
 from ..data_contracts.aabb_segmentation import AABBDetections
 from ..data_contracts.dataset import DatasetOut
@@ -28,24 +26,22 @@ class ScenePipeline:
         self, dataset_dir: Path, model_name: str, is_rotated: bool = True
     ) -> None:
         self.console = Console.with_prefix(self.__class__.__name__, "__init__")
+        gemini_config = GeminiClientConfig(
+            api_key=PathConfig().get_api_key("GOOGLE_API_KEY"),
+            model_name=model_name,
+            max_history_length=20,
+            context_window_size=10,
+        )
+        self.gemini_client = GeminiClient(gemini_config)
+
         self.dataset = self._create_dataset(dataset_dir, is_rotated)
         self.detector = self._create_detector(model_name)
         self._frame_cache: Dict[int, DatasetOut] = {}
         self._det_cache: Dict[int, AABBDetections] = {}
         self._subset_det_cache: Dict[Tuple[int, str], AABBDetections] = {}
 
-        # Initialize the new modular components
-        gemini_config = GeminiClientConfig(
-            api_key=PathConfig().get_api_key("GOOGLE_API_KEY"),
-            model_name=model_name,
-            max_history_length=20,
-            context_window_tokens=8000,
-            auto_mode_detection=True,
-            default_mode=OperationalMode.GENERAL_SCENE,
-        )
-        self.gemini_client = GeminiClient(gemini_config)
         self.response_generator = ResponseGenerator(
-            api_key=PathConfig().get_api_key("GOOGLE_API_KEY")
+            gemini_client=self.gemini_client, model_name=model_name
         )
         # Set preferred response styles
         self.response_generator.set_response_styles(
@@ -66,7 +62,7 @@ class ScenePipeline:
 
     def _create_detector(self, model_name: str) -> GeminiAABBDetSeg:
         cfg = GeminiAABBDetSegConfig(model_name=model_name)
-        return cfg.setup_target()
+        return GeminiAABBDetSeg(cfg, gemini_client=self.gemini_client)
 
     def load_frame(self, idx: int) -> DatasetOut:
         if idx not in self._frame_cache:
@@ -95,13 +91,13 @@ class ScenePipeline:
 
     def add_to_chat_history(self, user_message: str, assistant_response: str) -> None:
         """Add messages to the persistent chat history."""
-        self.gemini_client.add_user_message(user_message)
-        self.gemini_client.add_assistant_message(assistant_response)
+        self.gemini_client.add_message("user", user_message)
+        self.gemini_client.add_message("assistant", assistant_response)
 
     def set_operational_mode(self, mode: OperationalMode) -> None:
         """Set the current operational mode."""
         self.current_mode = mode
-        self.gemini_client.set_mode(mode)
+        self.gemini_client.current_mode = mode
 
     def get_operational_mode(self) -> OperationalMode:
         """Get the current operational mode."""
@@ -121,10 +117,6 @@ class ScenePipeline:
             text_query = user_input
 
         # Detect and switch mode if auto-detection is enabled
-        if self.gemini_client.config.auto_mode_detection:
-            detected_mode = self.gemini_client.detect_mode(text_query)
-            if detected_mode != self.current_mode:
-                self.set_operational_mode(detected_mode)
 
         # Check if this is a detection request that needs object data
         if self.is_detection_request(text_query):
@@ -136,13 +128,13 @@ class ScenePipeline:
             )
             # Use detection-enhanced response
             enhanced_query = f"{text_query}\n\nDetected objects: {detection_response}"
-            response_text = self.gemini_client.generate_response(
-                enhanced_query, frame.rgb_image
+            response_text, _ = self.gemini_client.generate_response(
+                enhanced_query, frame, tags=["pipeline"]
             )
         else:
             # Regular query processing
-            response_text = self.gemini_client.generate_response(
-                text_query, frame.rgb_image
+            response_text, _ = self.gemini_client.generate_response(
+                text_query, frame, tags=["pipeline"]
             )
 
         # For now, audio output is not implemented

--- a/tests/test_gemini_client.py
+++ b/tests/test_gemini_client.py
@@ -1,0 +1,45 @@
+import unittest
+from unittest.mock import Mock, patch
+
+from PIL import Image
+import numpy as np
+
+from spatial_guidance.gemini_client import GeminiClientConfig, GeminiClient
+from spatial_guidance.data_contracts.dataset import DatasetOut
+
+
+class GeminiClientTests(unittest.TestCase):
+    def setUp(self) -> None:
+        patcher = patch("spatial_guidance.gemini_client.gemini_client.genai.Client")
+        self.addCleanup(patcher.stop)
+        self.mock_client_cls = patcher.start()
+        self.mock_client = Mock()
+        self.mock_client.models.generate_content.return_value = Mock(text="ok")
+        self.mock_client_cls.return_value = self.mock_client
+
+        self.config = GeminiClientConfig()
+        self.client = self.config.setup_target()
+
+        self.dataset = DatasetOut(
+            rgb_image=Image.new("RGB", (2, 2)),
+            depth_image=Image.new("L", (2, 2)),
+            camera_intrinsics=np.eye(3),
+            camera_pose=np.eye(4),
+        )
+
+    def test_add_and_filter_by_tag(self) -> None:
+        self.client.add_message("user", "hi", tags=["greet"])
+        self.client.add_message("assistant", "hello", tags=["greet"])
+        ctx = self.client.get_context(tags=["greet"])
+        self.assertEqual(len(ctx), 2)
+        self.assertTrue(all("greet" in m.tags for m in ctx))
+
+    def test_generate_response_appends_history(self) -> None:
+        text, mode = self.client.generate_response("describe", self.dataset, tags=["scene"])
+        self.assertEqual(text, "ok")
+        self.assertEqual(len(self.client.chat_history), 2)
+        self.mock_client.models.generate_content.assert_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- extend `GeminiClient` with `generate_content`
- use the central client from `GeminiAABBDetSeg`
- update `ResponseGenerator` to rely on the shared client
- wire the client through `ScenePipeline`
- add new GeminiLive model and use it through GeminiClient
- hook GeminiClient into GeminiOBBDet

## Testing
- `python -m unittest tests.test_gemini_client -v`


------
https://chatgpt.com/codex/tasks/task_e_684582de33488325b75800bc052ddf90